### PR TITLE
docs: add more precise macos input source selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,8 @@ The creates "umlaut" pairs that can be added to the keymap using `&de_ae`, `&de_
 * On Windows and macOS there are additional requirements for unicode input to work. On
   Windows, one must install [WinCompose](https://github.com/samhocevar/wincompose) for
   full support (or use Win-Alt-Codes for limited support in select software). On
-  macOS one must enable unicode input in the system preferences.
+  macOS one must enable unicode input in the system preferences, by selecting 
+  `Unicode Hex Input` as input source.
 
 ### International characters
 


### PR DESCRIPTION
I struggled a bit on MacOS to actually get automatic unicode input to work. I looked for a general setting on turning on Unicode input on for the US Standard language I normally use. However, I was actually supposed to select Unicode Hex Input instead. As such I added a bit of an addendum to your docs.

Feel free to close/deny the pr if it is too benign ;D