### PR TITLE
Add 4 keypos layouts for the hillside keyboard.

### DIFF
--- a/keypos_def/keypos_46keys_hillside.h
+++ b/keypos_def/keypos_46keys_hillside.h
@@ -1,0 +1,76 @@
+/*                                      46 KEY MATRIX / LAYOUT MAPPING
+
+  ╭────────────────────────╮               ╭────────────────────────╮
+  │  0   1   2   3   4   5 │               │  6   7   8   9  10  11 │
+  │ 12  13  14  15  16  17 ╰──╮         ╭──╯ 18  19  20  21  22  23 │
+  │ 24  25  26  27  28  29  30╰────┬────╯31  32  33  34  35  36  37 │
+  ╰───────────────╮ 38  39  40  41 │ 42  43  44  45 ╭───────────────╯
+                  ╰────────────────┴────────────────╯
+ ╭─────────────────────────╮               ╭─────────────────────────╮
+ │ LT5 LT4 LT3 LT2 LT1 LT0 │               │ RT0 RT1 RT2 RT3 RT4 RT5 │
+ │ LM5 LM4 LM3 LM2 LM1 LM0 ╰──╮         ╭──╯ RM0 RM1 RM2 RM3 RM4 RM5 │
+ │ LB5 LB4 LB3 LB2 LB1 LB0 LH4╰────┬────╯RH4 RB0 RB1 RB2 RB3 RB4 RB5 │
+ ╰───────────────╮ LH3 LH2 LH1 LH0 │ RH0 RH1 RH2 RH3 ╭───────────────╯
+                 ╰─────────────────┴───── ───────────╯
+ T : Top
+ M : Middle
+ B : Bottom
+ H : Hand
+ P : Palm
+*/
+
+#pragma once
+
+#define LT0  5  // left-top row
+#define LT1  4
+#define LT2  3
+#define LT3  2
+#define LT4  1
+#define LT5  0
+
+#define RT0  6  // right-top row
+#define RT1  7
+#define RT2  8
+#define RT3  9
+#define RT4 10
+#define RT5 11
+
+#define LM0 17  // left-middle row
+#define LM1 16
+#define LM2 15
+#define LM3 14
+#define LM4 13
+#define LM5 12
+
+#define RM0 18  // right-middle row
+#define RM1 19
+#define RM2 20
+#define RM3 21
+#define RM4 22
+#define RM5 23
+
+#define LB0 29  // left-bottom row
+#define LB1 28
+#define LB2 27
+#define LB3 26
+#define LB4 25
+#define LB5 24
+
+#define RB0 32  // right-bottom row
+#define RB1 33
+#define RB2 34
+#define RB3 35
+#define RB4 36
+#define RB5 37
+
+#define LH0 41  // left thumb keys
+#define LH1 40
+#define LH2 39
+#define LH3 38
+#define LH4 30
+
+#define RH0 42  // right thumb keys
+#define RH1 43
+#define RH2 44
+#define RH3 45
+#define RH4 31

--- a/keypos_def/keypos_48keys_hillside.h
+++ b/keypos_def/keypos_48keys_hillside.h
@@ -1,0 +1,80 @@
+/*                                      48 KEY MATRIX / LAYOUT MAPPING
+
+  ╭────────────────────────╮               ╭────────────────────────╮
+  │  0   1   2   3   4   5 │               │  6   7   8   9  10  11 │
+  │ 12  13  14  15  16  17 ╰──╮         ╭──╯ 18  19  20  21  22  23 │
+  │ 24  25  26  27  28  29  30╰────┬────╯31  32  33  34  35  36  37 │
+  ╰───────╮ 38 ╭──╮ 39  40  41  42 │ 43  44  45  46 ╭──╮ 47 ╭───────╯
+          ╰────╯  ╰────────────────┴────────────────╯  ╰────╯
+ ╭─────────────────────────╮               ╭─────────────────────────╮
+ │ LT5 LT4 LT3 LT2 LT1 LT0 │               │ RT0 RT1 RT2 RT3 RT4 RT5 │
+ │ LM5 LM4 LM3 LM2 LM1 LM0 ╰──╮         ╭──╯ RM0 RM1 RM2 RM3 RM4 RM5 │
+ │ LB5 LB4 LB3 LB2 LB1 LB0 LH4╰────┬────╯RH4 RB0 RB1 RB2 RB3 RB4 RB5 │
+ ╰────────╮LP0╭───╮LH3 LH2 LH1 LH0 │ RH0 RH1 RH2 RH3╭───╮RP0╭────────╯
+          ╰───╯   ╰────────────────┴────────────────╯   ╰───╯
+ T : Top
+ M : Middle
+ B : Bottom
+ H : Hand
+ P : Palm
+*/
+
+#pragma once
+
+#define LT0  5  // left-top row
+#define LT1  4
+#define LT2  3
+#define LT3  2
+#define LT4  1
+#define LT5  0
+
+#define RT0  6  // right-top row
+#define RT1  7
+#define RT2  8
+#define RT3  9
+#define RT4 10
+#define RT5 11
+
+#define LM0 17  // left-middle row
+#define LM1 16
+#define LM2 15
+#define LM3 14
+#define LM4 13
+#define LM5 12
+
+#define RM0 18  // right-middle row
+#define RM1 19
+#define RM2 20
+#define RM3 21
+#define RM4 22
+#define RM5 23
+
+#define LB0 29  // left-bottom row
+#define LB1 28
+#define LB2 27
+#define LB3 26
+#define LB4 25
+#define LB5 24
+
+#define RB0 32  // right-bottom row
+#define RB1 33
+#define RB2 34
+#define RB3 35
+#define RB4 36
+#define RB5 37
+
+#define LH0 42  // left thumb keys
+#define LH1 41
+#define LH2 40
+#define LH3 39
+#define LH4 30
+
+#define RH0 43  // right thumb keys
+#define RH1 44
+#define RH2 45
+#define RH3 46
+#define RH4 31
+
+#define LP0 38  // left-palm keys
+
+#define RP0 47  // right-paml keys

--- a/keypos_def/keypos_52keys_hillside.h
+++ b/keypos_def/keypos_52keys_hillside.h
@@ -1,0 +1,84 @@
+/*                                      52 KEY MATRIX / LAYOUT MAPPING
+
+  ╭────────────────────────╮               ╭────────────────────────╮
+  │  0   1   2   3   4   5 │               │  6   7   8   9  10  11 │
+  │ 12  13  14  15  16  17 ╰──╮         ╭──╯ 18  19  20  21  22  23 │
+  │ 24  25  26  27  28  29  30╰────┬────╯31  32  33  34  35  36  37 │
+  │ 38  39  40      41  42  43  44 │ 45  46  47  48      49  50  51 │
+  ╰────────────────────────────────┴────────────────────────────────╯
+ ╭─────────────────────────╮               ╭─────────────────────────╮
+ │ LT5 LT4 LT3 LT2 LT1 LT0 │               │ RT0 RT1 RT2 RT3 RT4 RT5 │
+ │ LM5 LM4 LM3 LM2 LM1 LM0 ╰──╮         ╭──╯ RM0 RM1 RM2 RM3 RM4 RM5 │
+ │ LB5 LB4 LB3 LB2 LB1 LB0 LH4╰────┬────╯RH4 RB0 RB1 RB2 RB3 RB4 RB5 │
+ │ LP2 LP1 LP0╭───╮LH3 LH2 LH1 LH0 │ RH0 RH1 RH2 RH3╭───╮RP0 RP1 RP2 │
+ ╰────────────╯   ╰────────────────┴────────────────╯   ╰────────────╯
+ T : Top
+ M : Middle
+ B : Bottom
+ H : Hand
+ P : Palm
+*/
+
+#pragma once
+
+#define LT0  5  // left-top row
+#define LT1  4
+#define LT2  3
+#define LT3  2
+#define LT4  1
+#define LT5  0
+
+#define RT0  6  // right-top row
+#define RT1  7
+#define RT2  8
+#define RT3  9
+#define RT4 10
+#define RT5 11
+
+#define LM0 17  // left-middle row
+#define LM1 16
+#define LM2 15
+#define LM3 14
+#define LM4 13
+#define LM5 12
+
+#define RM0 18  // right-middle row
+#define RM1 19
+#define RM2 20
+#define RM3 21
+#define RM4 22
+#define RM5 23
+
+#define LB0 29  // left-bottom row
+#define LB1 28
+#define LB2 27
+#define LB3 26
+#define LB4 25
+#define LB5 24
+
+#define RB0 32  // right-bottom row
+#define RB1 33
+#define RB2 34
+#define RB3 35
+#define RB4 36
+#define RB5 37
+
+#define LH0 44  // left thumb keys
+#define LH1 43
+#define LH2 42
+#define LH3 41
+#define LH4 30
+
+#define RH0 45  // right thumb keys
+#define RH1 46
+#define RH2 47
+#define RH3 48
+#define RH4 31
+
+#define LP0 40  // left-palm keys
+#define LP1 41
+#define LP2 42
+
+#define RP0 49  // right-paml keys
+#define RP1 50
+#define RP2 51

--- a/keypos_def/keypos_56keys_hillside.h
+++ b/keypos_def/keypos_56keys_hillside.h
@@ -1,0 +1,91 @@
+/*                                      48 KEY MATRIX / LAYOUT MAPPING
+
+  ╭────────────────────────╮               ╭────────────────────────╮
+  │  0   1   2   3   4   5 │               │  6   7   8   9  10  11 │
+  │ 12  13  14  15  16  17 ╰──╮         ╭──╯ 18  19  20  21  22  23 │
+  │ 24  25  26  27  28  29  30╰────┬────╯31  32  33  34  35  36  37 │
+  │ 38      39      40  41  42  43 │ 44  45  46  47      48      49 │
+  ╰───╮ 50  51  52 ╭───────────────┴───────────────╮ 53  54  55 ╭───╯
+      ╰────────────╯                               ╰────────────╯
+ ╭─────────────────────────╮               ╭─────────────────────────╮
+ │ LT5 LT4 LT3 LT2 LT1 LT0 │               │ RT0 RT1 RT2 RT3 RT4 RT5 │
+ │ LM5 LM4 LM3 LM2 LM1 LM0 ╰──╮         ╭──╯ RM0 RM1 RM2 RM3 RM4 RM5 │
+ │ LB5 LB4 LB3 LB2 LB1 LB0 LH4╰────┬────╯RH4 RB0 RB1 RB2 RB3 RB4 RB5 │
+ │ LP1     LP0     LH3 LH2 LH1 LH0 │ RH0 RH1 RH2 RH3     RP0     RP1 │
+ ╰───╮LP4 LP3 LP2╭─────────────────┴────────────────╮RP2 RP3 RP4╭────╯
+     ╰───────────╯                                  ╰───────────╯
+
+ T : Top
+ M : Middle
+ B : Bottom
+ H : Hand
+ P : Palm
+*/
+
+#pragma once
+
+#define LT0  5  // left-top row
+#define LT1  4
+#define LT2  3
+#define LT3  2
+#define LT4  1
+#define LT5  0
+
+#define RT0  6  // right-top row
+#define RT1  7
+#define RT2  8
+#define RT3  9
+#define RT4 10
+#define RT5 11
+
+#define LM0 17  // left-middle row
+#define LM1 16
+#define LM2 15
+#define LM3 14
+#define LM4 13
+#define LM5 12
+
+#define RM0 18  // right-middle row
+#define RM1 19
+#define RM2 20
+#define RM3 21
+#define RM4 22
+#define RM5 23
+
+#define LB0 29  // left-bottom row
+#define LB1 28
+#define LB2 27
+#define LB3 26
+#define LB4 25
+#define LB5 24
+
+#define RB0 32  // right-bottom row
+#define RB1 33
+#define RB2 34
+#define RB3 35
+#define RB4 36
+#define RB5 37
+
+#define LH0 43  // left thumb keys
+#define LH1 42
+#define LH2 41
+#define LH3 40
+#define LH4 30
+
+#define RH0 44  // right thumb keys
+#define RH1 45
+#define RH2 46
+#define RH3 47
+#define RH4 31
+
+#define LP0 39  // left-palm keys
+#define LP1 38
+#define LP2 52
+#define LP3 51
+#define LP4 50
+
+#define RP0 48  // right-paml keys
+#define RP1 49
+#define RP2 53
+#define RP3 54
+#define RP4 55


### PR DESCRIPTION
This adds the 4 layouts for the hillside. I based everything around the 46 and kept the thumb clusters as LH/RH and the other outside keys i named as "palm" keys, making LP*/RP*