### PR TITLE
Parameterized macros support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ hold-tap, key-repeat, macro, mod-morph, sticky-key, tap-dance or tri-state.
 * `name`: a unique string chosen by the user (e.g., `my_behavior`). The new behavior can
   be added to the keymap using `&name` (e.g., `&my_behavior`).
 * `type`: the behavior to be created. It must be one of the following:
-  `caps_word`, `hold_tap`, `key_repeat`, `macro`, `mod_morph`, `sticky_key`,
-  `tap_dance` or `tri_state`. Note that multiword behaviors are separated by underscores (`_`).
+  `caps_word`, `hold_tap`, `key_repeat`, `macro`, `macro_one_param`,
+  `macro_two_param`, `mod_morph`, `sticky_key`, `tap_dance` or `tri_state`.
+  Note that multiword behaviors are separated by underscores (`_`).
 * `specification`: the custom behavior code. It should contain the
   body of the corresponding [ZMK behavior configuration](https://zmk.dev/docs/config/behaviors)
   without the `label`, `#binding-cells` and `compatible` properties and without the

--- a/helper.h
+++ b/helper.h
@@ -11,15 +11,17 @@
 
 /* ZMK_BEHAVIOR */
 
-#define ZMK_BEHAVIOR_CORE_caps_word      compatible = "zmk,behavior-caps-word";      #binding-cells = <0>
-#define ZMK_BEHAVIOR_CORE_dynamic_macro  compatible = "zmk,behavior-dynamic-macro";  #binding-cells = <1>
-#define ZMK_BEHAVIOR_CORE_hold_tap       compatible = "zmk,behavior-hold-tap";       #binding-cells = <2>
-#define ZMK_BEHAVIOR_CORE_key_repeat     compatible = "zmk,behavior-key-repeat";     #binding-cells = <0>
-#define ZMK_BEHAVIOR_CORE_macro          compatible = "zmk,behavior-macro";          #binding-cells = <0>
-#define ZMK_BEHAVIOR_CORE_mod_morph      compatible = "zmk,behavior-mod-morph";      #binding-cells = <0>
-#define ZMK_BEHAVIOR_CORE_sticky_key     compatible = "zmk,behavior-sticky-key";     #binding-cells = <1>
-#define ZMK_BEHAVIOR_CORE_tap_dance      compatible = "zmk,behavior-tap-dance";      #binding-cells = <0>
-#define ZMK_BEHAVIOR_CORE_tri_state      compatible = "zmk,behavior-tri-state";      #binding-cells = <0>
+#define ZMK_BEHAVIOR_CORE_caps_word       compatible = "zmk,behavior-caps-word";       #binding-cells = <0>
+#define ZMK_BEHAVIOR_CORE_dynamic_macro   compatible = "zmk,behavior-dynamic-macro";   #binding-cells = <1>
+#define ZMK_BEHAVIOR_CORE_hold_tap        compatible = "zmk,behavior-hold-tap";        #binding-cells = <2>
+#define ZMK_BEHAVIOR_CORE_key_repeat      compatible = "zmk,behavior-key-repeat";      #binding-cells = <0>
+#define ZMK_BEHAVIOR_CORE_macro           compatible = "zmk,behavior-macro";           #binding-cells = <0>
+#define ZMK_BEHAVIOR_CORE_macro_one_param compatible = "zmk,behavior-macro-one-param"; #binding-cells = <1>
+#define ZMK_BEHAVIOR_CORE_macro_two_param compatible = "zmk,behavior-macro-two-param"; #binding-cells = <2>
+#define ZMK_BEHAVIOR_CORE_mod_morph       compatible = "zmk,behavior-mod-morph";       #binding-cells = <0>
+#define ZMK_BEHAVIOR_CORE_sticky_key      compatible = "zmk,behavior-sticky-key";      #binding-cells = <1>
+#define ZMK_BEHAVIOR_CORE_tap_dance       compatible = "zmk,behavior-tap-dance";       #binding-cells = <0>
+#define ZMK_BEHAVIOR_CORE_tri_state       compatible = "zmk,behavior-tri-state";       #binding-cells = <0>
 
 #define ZMK_BEHAVIOR(name, type, ...) \
     / { \


### PR DESCRIPTION
Hi!
ZMK [recently added two new behaviors for macros](https://github.com/zmkfirmware/zmk/pull/1232), both allowing to pass parameters from the keymap.

I've simply added the  `macro-one-param` and  `macro-two-param` definitions into the helper and it seems to work fine when configuring bindings [according to documentation](https://zmk.dev/docs/behaviors/macros#parameters). 

Example:

```c
/* Calling this macro in keybindings with "MAC K" where K is a keypress parameter */
ZMK_BEHAVIOR(MAC, macro_one_param, bindings =
    <&macro_param_1to1>,
    <&kp MACRO_PLACEHOLDER>;)
``` 

Also added those two to the readme, in the allowed behavior types.
Hope this helps!

