### PR TITLE
Add capital eszett (ẞ) to german.dtsi

### DIFF
--- a/international_chars/german.dtsi
+++ b/international_chars/german.dtsi
@@ -2,5 +2,5 @@
 ZMK_UNICODE_PAIR(   de_ae,      N0, N0,  E, N4,    N0, N0,  C, N4)
 ZMK_UNICODE_PAIR(   de_oe,      N0, N0,  F, N6,    N0, N0,  D, N6)
 ZMK_UNICODE_PAIR(   de_ue,      N0, N0,  F,  C,    N0, N0,  D,  C)
-ZMK_UNICODE_SINGLE( de_eszett,  N0, N0,  D,  F)
+ZMK_UNICODE_SINGLE( de_eszett,  N0, N0,  D,  F,    N1, E,   N9, E)
 

--- a/international_chars/german.dtsi
+++ b/international_chars/german.dtsi
@@ -2,5 +2,5 @@
 ZMK_UNICODE_PAIR(   de_ae,      N0, N0,  E, N4,    N0, N0,  C, N4)
 ZMK_UNICODE_PAIR(   de_oe,      N0, N0,  F, N6,    N0, N0,  D, N6)
 ZMK_UNICODE_PAIR(   de_ue,      N0, N0,  F,  C,    N0, N0,  D,  C)
-ZMK_UNICODE_SINGLE( de_eszett,  N0, N0,  D,  F,    N1, E,   N9, E)
+ZMK_UNICODE_PAIR(de_eszett,     N0, N0,  D,  F,    N1, E,   N9, E)
 


### PR DESCRIPTION
Official part of German orthography since 2017, see https://en.wikipedia.org/wiki/%C3%9F#Development_of_a_capital_form