### PR TITLE
fix: Osprette error

### DIFF
--- a/keypos_def/keypos_34keys_osprette.h
+++ b/keypos_def/keypos_34keys_osprette.h
@@ -31,7 +31,7 @@
 #define RM2 16
 #define RM3 17
 #define RM4 18
-#define RT4 19
+#define RM5 19
 
 #define LB0 24  // left-bottom row
 #define LB1 23


### PR DESCRIPTION
This error got through. This is correct. Don't know how that slipped through the cracks.