### PR TITLE
Fix typo in keymap-drawer config file name

### DIFF
--- a/docs/keymap_drawer.md
+++ b/docs/keymap_drawer.md
@@ -22,7 +22,7 @@ to do anything specials; keymap-drawer will find the headers automatically.
      zmk_additional_includes: ["zmk-helpers/include"]
    ```
 
-   By default the config file will be expected to be at `keymap-drawer.config.yaml` at the repo root.
+   By default the config file will be expected to be at `keymap_drawer.config.yaml` at the repo root.
 
 ## Running keymap-drawer locally
 


### PR DESCRIPTION
Source: https://github.com/caksoylar/keymap-drawer/blob/2d0588fc7f2f1f446e876308e34e26bec1c21f3f/.github/workflows/draw-zmk.yml#L14