### PR TITLE
maint!: Remove ALL alias for selecting combo layers

### DIFF
--- a/docs/core_helpers.md
+++ b/docs/core_helpers.md
@@ -128,11 +128,11 @@ default can be globally overwritten with:
 
 <details><summary>Simple combo</summary>
 
-This creates an "escape" combo that is active on all layers and which is triggered when the 0th and
+This creates an "escape" combo that is active on layers `2` and `3` and which is triggered when the 0th and
 1st keys are pressed jointly within 25ms.
 
 ```C++
-ZMK_COMBO(esc,  &kp ESC, 0 1, ALL, 25)
+ZMK_COMBO(esc,  &kp ESC, 0 1, 2 3, 25)
 ```
 
 </details>

--- a/docs/key_labels.md
+++ b/docs/key_labels.md
@@ -67,8 +67,8 @@ This defines a "copy"-combo for the middle + ring finger on the left bottom row,
 for the index + middle finger on the left bottom row. Both combos are active on all layers.
 
 ```c
-ZMK_COMBO(copy,  &kp LC(C), LB2 LB3, ALL)
-ZMK_COMBO(paste, &kp LC(V), LB1 LB2, ALL)
+ZMK_COMBO(copy,  &kp LC(C), LB2 LB3)
+ZMK_COMBO(paste, &kp LC(V), LB1 LB2)
 ```
 
 </details>

--- a/examples/zmk-config/config/cradio.keymap
+++ b/examples/zmk-config/config/cradio.keymap
@@ -66,8 +66,8 @@ ZMK_CONDITIONAL_LAYER(ger, NAV NUM, GER)
 
 // combos
 ZMK_COMBO(sleep,    &win_sleep,  RT3 RT4, NAV)  // put Windows to sleep, only active on NAV layer
-ZMK_COMBO(copy_cut, &copy_cut,   LB2 LB3, ALL)  // copy on tap, cut on double-tap, active on all layers
-ZMK_COMBO(paste,    &kp LS(INS), LB1 LB2, ALL)  // paste, active on all layers
+ZMK_COMBO(copy_cut, &copy_cut,   LB2 LB3)       // copy on tap, cut on double-tap, active on all layers
+ZMK_COMBO(paste,    &kp LS(INS), LB1 LB2)       // paste, active on all layers
 
 /* Keymap */
 

--- a/include/zmk-helpers/helper.h
+++ b/include/zmk-helpers/helper.h
@@ -106,14 +106,22 @@
 
 /* ZMK_COMBOS */
 
-#define ALL 0xff
 #if !defined COMBO_TERM
     #define COMBO_TERM 30
 #endif
 
 #define ZMK_COMBO(...) CONCAT(ZMK_COMBO_, VARGS(__VA_ARGS__))(__VA_ARGS__)
 #define ZMK_COMBO_3(name, combo_bindings, keypos) \
-    ZMK_COMBO_4(name, combo_bindings, keypos, ALL)
+    / { \
+        combos { \
+            compatible = "zmk,combos"; \
+            combo_ ## name { \
+                timeout-ms = <COMBO_TERM>; \
+                bindings = <combo_bindings>; \
+                key-positions = <keypos>; \
+            }; \
+        }; \
+    };
 #define ZMK_COMBO_4(name, combo_bindings, keypos, combo_layers) \
     ZMK_COMBO_5(name, combo_bindings, keypos, combo_layers, COMBO_TERM)
 #define ZMK_COMBO_5(name, combo_bindings, keypos, combo_layers, combo_timeout) \


### PR DESCRIPTION
Fixes #101 

ZMK removed the ability to explicitly select all layers. This PR updates helpers to accommodate the change:

1/ Explicitly define `ZMK_COMBO_3` without setting layers.
2/ Remove `ALL` alias.

BREAKING CHANGE: The `ALL` alias no longer works. Calling `ZMK_COMBO` with only 3 arguments, will continue to select all layers. 