### PR TITLE
Add Helix/Felix keyboard layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ The following layouts are currently implemented.
 | `adv360.h`               | 76               | Kinesis Advantage360 Pro               |
 | `eyelash42.h`            | 42+              | Eyelash Corne with Joystick & Encoder  |
 | `glove80.h`              | 80               | Glove80                                |
+| `helix.h`                | 64               | Helix / Felix                          |
 | `hillside_*.h`           | 46, 48, 52 or 56 | Hillside family                        |
 | `hummingbird.h`          | 30               | Hummingbird, Tern, Phantom, Rufous     |
 | `jian.h`                 | 44               | Jian, Jorne                            |

--- a/include/zmk-helpers/key-labels/helix.h
+++ b/include/zmk-helpers/key-labels/helix.h
@@ -1,0 +1,103 @@
+/*                  Felix/Helix KEY MATRIX / LAYOUT MAPPING
+
+         ╭────────────────────────────╮   ╭────────────────────────────╮
+         │  0   1   2   3   4   5     │   │      6   7   8   9  10  11 │
+         │ 12  13  14  15  16  17     │   │     18  19  20  21  22  23 │
+         │ 24  25  26  27  28  29     │   │     30  31  32  33  34  35 │
+         │ 36  37  38  39  40  41  42 │   │ 43  44  45  46  47  48  49 │
+         │ 50  51  52  53  54  55  56 │   │ 57  58  59  60  61  62  63 │
+         ╰────────────────────────────╯   ╰────────────────────────────╯
+
+
+  ╭───────────────────────────────────╮   ╭───────────────────────────────────╮
+  │ LN5  LN4  LN3  LN2  LN1  LN0      │   │      RN0  RN1  RN2  RN3  RN4  RN5 │
+  │ LT5  LT4  LT3  LT2  LT1  LT0      │   │      RT0  RT1  RT2  RT3  RT4  RT5 │
+  │ LM5  LM4  LM3  LM2  LM1  LM0      │   │      RM0  RM1  RM2  RM3  RM4  RM5 │
+  │ LB5  LB4  LB3  LB2  LB1  LB0  LF1 │   │ RF1  RB0  RB1  RB2  RB3  RB4  RB5 │
+  │ LH5  LH4  LH3  LH2  LH1  LH0  LF0 │   │ RF0  RH0  RH1  RH2  RH3  RH4  RH5 │
+  ╰───────────────────────────────────╯   ╰───────────────────────────────────╯
+*/
+#pragma once
+
+
+#define LN0  5  // left-number row
+#define LN1  4
+#define LN2  3
+#define LN3  2
+#define LN4  1
+#define LN5  0
+
+#define RN0  6  // right-number row
+#define RN1  7
+#define RN2  8
+#define RN3  9
+#define RN4 10
+#define RN5 11
+
+#define LT0 17  // left-top row
+#define LT1 16
+#define LT2 15
+#define LT3 14
+#define LT4 13
+#define LT5 12
+
+#define RT0 18  // right-top row
+#define RT1 19
+#define RT2 20
+#define RT3 21
+#define RT4 22
+#define RT5 23
+
+#define LM0 29  // left-middle row
+#define LM1 28
+#define LM2 27
+#define LM3 26
+#define LM4 25
+#define LM5 24
+
+#define RM0 30  // right-middle row
+#define RM1 31
+#define RM2 32
+#define RM3 33
+#define RM4 34
+#define RM5 35
+
+#define LB0 41  // left-bottom row
+#define LB1 40
+#define LB2 39
+#define LB3 38
+#define LB4 37
+#define LB5 36
+
+#define RB0 44  // right-bottom row
+#define RB1 45
+#define RB2 46
+#define RB3 47
+#define RB4 48
+#define RB5 49
+
+#define LH0 55  // left thumb keys
+#define LH1 54
+#define LH2 53
+#define LH3 52
+#define LH4 51
+#define LH5 50
+
+#define RH0 58  // right thumb keys
+#define RH1 59
+#define RH2 60
+#define RH3 61
+#define RH4 62
+#define RH5 63
+
+#define LF1 42  // inner left thumb key
+#define LF0 56  // inner left bottom key
+#define RF1 43  // inner right bottom key
+#define RF0 57  // inner right thumb key
+
+#define NUMROW LN0 LN1 LN2 LN3 LN4 LN5 RN0 RN1 RN2 RN3 RN4 RN5
+#define KEYS_L LT0 LT1 LT2 LT3 LT4 LT5 LM0 LM1 LM2 LM3 LM4 LM5 LB0 LB1 LB2 LB3 LB4 LB5 LF0 LF1
+#define KEYS_R RT0 RT1 RT2 RT3 RT4 RT5 RM0 RM1 RM2 RM3 RM4 RM5 RB0 RB1 RB2 RB3 RB4 RB5 RF0 RF1
+#define THUMBS_L LH0 LH1 LH2 LH3 LH4 LH5
+#define THUMBS_R RH0 RH1 RH2 RH3 RH4 RH5
+#define THUMB    THUMBS_L THUMBS_R


### PR DESCRIPTION
Would love your opinion on the inner bottom row keys. I hesitate to shift the numbering outward so that the inner column on numrow, top, middle start at 1 -- doesn't this violate the principle that key-labels are *standardized* to make keymaps portable across keyboards?

I am unclear on the differences in the handling of the LH/RH vs LF/RF in:

- [5x6.h](https://github.com/urob/zmk-helpers/blob/main/include/zmk-helpers/key-labels/5x6.h)
- [70.h](https://github.com/urob/zmk-helpers/blob/main/include/zmk-helpers/key-labels/70.h)
- [redox.h](https://github.com/urob/zmk-helpers/blob/main/include/zmk-helpers/key-labels/redox.h)

I settled on following the approach in [kyria.h](https://github.com/urob/zmk-helpers/blob/main/include/zmk-helpers/key-labels/kyria.h) to use LH/RH to designate the lowest physical row as t**h**umb keys and use LF0 and RF0 for the inner bottom row keys. I think this will support scaling up smaller 34/36-key layouts to the larger board in the most intuitive way, but happy to change it.

Side-note, I saw #90 but wasn't sure if you had settled on an aliasing approach, so I just kept this limited to `helix.h` and Felix users (myself included) can adjust :)